### PR TITLE
Add OCR engine and preprocessing modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 openai
 pytest
 regex
+pytesseract

--- a/src/image_preprocess.py
+++ b/src/image_preprocess.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Union
+
+from PIL import Image, ImageOps, ImageFilter
+
+
+def preprocess_image(input_path: Union[str, Path], output_path: Union[str, Path]) -> None:
+    """Convert the image to grayscale and enhance contrast.
+
+    Parameters
+    ----------
+    input_path: Union[str, Path]
+        Path to the original image file.
+    output_path: Union[str, Path]
+        Path where the preprocessed image will be saved.
+    """
+    with Image.open(input_path) as img:
+        gray = ImageOps.grayscale(img)
+        enhanced = ImageOps.autocontrast(gray)
+        enhanced = enhanced.filter(ImageFilter.MedianFilter(size=3))
+        enhanced.save(output_path)

--- a/src/ocr_engine.py
+++ b/src/ocr_engine.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from typing import Union
+
+from PIL import Image
+
+try:
+    import pytesseract
+    from pytesseract import Output
+except ImportError:  # pragma: no cover - runtime check
+    pytesseract = None
+    Output = None
+
+
+def run_tesseract(image_path: Union[str, Path]) -> dict:
+    """Run Tesseract OCR on the given image.
+
+    Parameters
+    ----------
+    image_path: Union[str, Path]
+        Path to the image file to be processed.
+
+    Returns
+    -------
+    dict
+        A dictionary with extracted ``text`` and average ``confidence``.
+    """
+    if pytesseract is None:  # pragma: no cover - handled at runtime
+        raise ImportError("pytesseract is required to use run_tesseract")
+
+    with Image.open(image_path) as img:
+        data = pytesseract.image_to_data(img, output_type=Output.DICT)
+
+    words = [w for w in data.get('text', []) if w.strip()]
+    text = " ".join(words)
+
+    confs = [int(c) for c in data.get('conf', []) if c != '-1']
+    confidence = sum(confs) / len(confs) / 100 if confs else 0.0
+
+    return {"text": text, "confidence": confidence}

--- a/tests/test_image_ocr.py
+++ b/tests/test_image_ocr.py
@@ -1,0 +1,68 @@
+import pytest
+from PIL import Image
+from unittest import mock
+
+from src.image_preprocess import preprocess_image
+from src.ocr_engine import run_tesseract
+
+
+def test_preprocess_image(tmp_path, monkeypatch):
+    input_path = tmp_path / "input.png"
+    output_path = tmp_path / "output.png"
+    Image.new("RGB", (10, 10), "white").save(input_path)
+
+    original_open = Image.open
+    open_mock = mock.MagicMock(side_effect=original_open)
+    monkeypatch.setattr("src.image_preprocess.Image.open", open_mock)
+
+    original_save = Image.Image.save
+    save_mock = mock.MagicMock()
+
+    def save_stub(self, fp, *args, **kwargs):
+        save_mock(fp)
+        return original_save(self, fp, *args, **kwargs)
+
+    monkeypatch.setattr(Image.Image, "save", save_stub)
+
+    preprocess_image(input_path, output_path)
+
+    open_mock.assert_called_once_with(input_path)
+    save_mock.assert_called_once_with(output_path)
+
+    assert output_path.exists()
+    with Image.open(output_path) as img:
+        assert img.mode == "L"
+
+
+def test_run_tesseract(tmp_path, monkeypatch):
+    img_path = tmp_path / "img.png"
+    Image.new("RGB", (10, 10), "white").save(img_path)
+
+    dummy_data = {
+        "text": ["Hello", "World", ""],
+        "conf": ["95", "80", "-1"],
+    }
+
+    def fake_image_to_data(image, output_type):
+        assert output_type == DummyOutput.DICT
+        return dummy_data
+
+    class DummyOutput:
+        DICT = "dict"
+
+    fake_pytesseract = mock.MagicMock()
+    fake_pytesseract.image_to_data = mock.MagicMock(side_effect=fake_image_to_data)
+
+    monkeypatch.setattr("src.ocr_engine.pytesseract", fake_pytesseract)
+    monkeypatch.setattr("src.ocr_engine.Output", DummyOutput)
+
+    result = run_tesseract(img_path)
+    assert result["text"] == "Hello World"
+    assert result["confidence"] == pytest.approx((95 + 80) / 2 / 100)
+    fake_pytesseract.image_to_data.assert_called_once()
+
+
+def test_run_tesseract_import_error(monkeypatch):
+    monkeypatch.setattr("src.ocr_engine.pytesseract", None)
+    with pytest.raises(ImportError):
+        run_tesseract("dummy.png")


### PR DESCRIPTION
## Summary
- implement `run_tesseract` wrapper around Tesseract OCR
- add basic Pillow-based image preprocessing utility
- declare `pytesseract` dependency
- add unit tests for image preprocessing and OCR wrapper

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement pytesseract)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be1bc9014832faa76133d73d85e60