### PR TITLE
Load OCR threshold from config and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,33 @@
 Extracts text from herbarium specimen sheets using local OCR (Tesseract) with fallback to OpenAI Vision.
 
 ## Setup
+
+### Prerequisites
+Install the [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) binary on your system before running the pipeline:
+
+```bash
+# macOS
+brew install tesseract
+
+# Debian/Ubuntu
+sudo apt install tesseract-ocr
+
+# Windows (Chocolatey)
+choco install tesseract
+```
+
+### Install dependencies
 ```bash
 cp .env.example .env
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync
-uv run python src/main.py
+uv run python -m src.main
 ```
+
+### Input and output
+Place specimen images in the `input/` directory.
+OCR output is saved to `output/ocr_texts/` with processing metadata in `output/status.csv`.
+Extracted Darwin Core fields are written to `output/dwc_output/`.
 
 Dependencies are declared in `pyproject.toml`. To export a pinned `requirements.txt` run:
 ```bash

--- a/src/config.py
+++ b/src/config.py
@@ -7,3 +7,4 @@ load_dotenv()
 class Config:
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
     MODE = os.getenv('APP_MODE', 'local')
+    OCR_THRESHOLD = float(os.getenv('OCR_THRESHOLD', 0.85))

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,8 @@ from src.image_preprocess import preprocess_image
 from src.field_extractor import extract_fields
 from src.validator import validate_fields
 
+OCR_THRESHOLD = Config.OCR_THRESHOLD
+
 INPUT_DIR = Path('input')
 OUTPUT_DIR = Path('output/ocr_texts')
 STATUS_FILE = Path('output/status.csv')
@@ -43,7 +45,7 @@ def process_image(img_path: Path):
     result = run_tesseract(pre_path)
     result['source'] = 'tesseract'
 
-    if result['confidence'] < Config.OCR_THRESHOLD:
+    if result['confidence'] < OCR_THRESHOLD:
         print(f'Low confidence ({result["confidence"]:.2f}) → OpenAI Vision fallback.')
         oa_result = run_openai_vision(pre_path)
         if oa_result.get('text'):


### PR DESCRIPTION
## Summary
- make OCR fallback threshold configurable through `Config`
- document Tesseract installation and run instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e7baf6bac832f9db9de9d1b2a4b38